### PR TITLE
Update .gitignore to ignore certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ go_build_stash_us_cray_com_HMS_hms_capmc_cmd_capmcd
 capmc-service
 kubernetes/.packaged/
 
+# Prevent certificates from getting checked in
+*.ca
+*.cer
+*.crt
+*.csr
+*.key
+*.pem


### PR DESCRIPTION
Update .gitignore to ignore certificates to help prevent check in of sensitive files in the future.